### PR TITLE
build(deps): updated a5-js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,7 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "rslib build",
     "check": "biome check --write",
@@ -43,15 +41,11 @@
     "vitest": "^3.1.1"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "@biomejs/biome",
-      "core-js",
-      "esbuild"
-    ]
+    "onlyBuiltDependencies": ["@biomejs/biome", "core-js", "esbuild"]
   },
   "dependencies": {
     "@turf/helpers": "^7.2.0",
-    "a5-js": "^0.0.3",
+    "a5-js": "^0.2.0",
     "bbox-helper-functions": "^3.3.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^7.2.0
         version: 7.2.0
       a5-js:
-        specifier: ^0.0.3
-        version: 0.0.3
+        specifier: ^0.2.0
+        version: 0.2.0
       bbox-helper-functions:
         specifier: ^3.3.0
         version: 3.3.0
@@ -590,8 +590,8 @@ packages:
   '@vitest/utils@3.1.2':
     resolution: {integrity: sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==}
 
-  a5-js@0.0.3:
-    resolution: {integrity: sha512-jkpbmqsvPR36X1Y0XrfAu1WtOD8k9bchmctJRlfrgvg+BegPnjA4Zy97pDQDJNI7TtUrvXS4IYQXDXsZd8+ZaA==}
+  a5-js@0.2.0:
+    resolution: {integrity: sha512-Gze9pambXy3PkMSMxf5qej5M1EiznJkphI0pyaVwG0w0JwVq8DfTz0wGgjgLqaSDvXJbf5aKLKgWvhBj/CaZOA==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1369,7 +1369,7 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
-  a5-js@0.0.3:
+  a5-js@0.2.0:
     dependencies:
       gl-matrix: 3.4.3
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,10 +69,7 @@ export function a5ToPolygonFeature(
   cell: bigint,
   properties: GeoJsonProperties = {},
 ): Feature<Polygon> {
-  const ring = cellToBoundary(cell);
-  // Close the ring
-  ring.push(ring[0]);
-  return polygon([ring], properties);
+  return polygon([cellToBoundary(cell)], properties);
 }
 
 /**

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,26 @@
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import * as lib from '../src';
+import type { Feature, Polygon } from 'geojson';
+import { lonLatToCell } from 'a5-js';
 
 test('Library is exported', () => {
   expect(lib).toBeDefined();
+});
+
+describe('A5 cell polygon ring closure', () => {
+  const testCell = lonLatToCell([-3.694153, 40.410359], 8);
+
+  test('a5ToPolygonFeature returns a closed ring', () => {
+    const feature: Feature<Polygon> = lib.a5ToPolygonFeature(testCell);
+    const coords = feature.geometry.coordinates[0];
+
+    expect(coords[0]).toEqual(coords[coords.length - 1]); // El anillo debe estar cerrado
+  });
+
+  test('a5ToPolygonGeometry returns a closed ring', () => {
+    const geometry: Polygon = lib.a5ToPolygonGeometry(testCell);
+    const coords = geometry.coordinates[0];
+
+    expect(coords[0]).toEqual(coords[coords.length - 1]); // El anillo debe estar cerrado
+  });
 });


### PR DESCRIPTION
Updates a5-js library to 0.2.0 to adapt to lib changes as per #1 

Removed ring closure as base lib does it.

Added tests.